### PR TITLE
returning res.locals.getBreweries from a post request to /login

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -52,7 +52,7 @@ app.delete('/deleteUser',  userController.deleteUser, (req, res) => {
 
 app.post('/login', cookieController.storeUserInfo, userController.verifyLogin, brewController.getBreweries, (req, res) => {
   // console.log("finished the login process, back in server.js, res.locals is storing ", res.locals.getBreweries);
-  res.status(200).json(res.locals.userInfo); // do they need userInfo to be sent back?
+  res.status(200).json(res.locals.getBreweries); // do they need userInfo to be sent back?
 });
 
 


### PR DESCRIPTION
it was returning res.locals.userInfo. I had changed it already to res.locals.getBreweries but I see that the MACAW repo somehow got changed back to res.locals.userInfo. which means that a successful login is returning the userInfo back to the front